### PR TITLE
Update class-twitter.php

### DIFF
--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -881,7 +881,7 @@ class WPSEO_OpenGraph_Image {
 	private function get_singular_image() {
 		global $post;
 
-		if ( $this->get_opengraph_image_post() ) {
+		if ( $this->get_opengraph_image_post( $post->ID ) ) {
 			return;
 		}
 

--- a/frontend/class-twitter.php
+++ b/frontend/class-twitter.php
@@ -389,11 +389,12 @@ class WPSEO_Twitter {
 		}
 
 		if ( is_singular() ) {
-			if ( $this->image_from_meta_values_output() ) {
+			
+			$post_id = get_the_ID();
+			
+			if ( $this->image_from_meta_values_output( $post_id ) ) {
 				return;
 			}
-
-			$post_id = get_the_ID();
 
 			if ( $this->image_of_attachment_page_output( $post_id ) ) {
 				return;


### PR DESCRIPTION
## Summary

Facebook and Twitter meta image overrides not being pulled in on singular posts

## Test instructions

This PR can be tested by following these steps:

* Use the Yoast SEO plugin to add overrides for the Facebook and Twitter images for a post
* Update/save the post
* View source on the page, see that the featured image is being pulled through instead of the override images set


Fixes #

og:image and twitter:image file overrides now display, once the post id is passed to their respective functions